### PR TITLE
Show Help when no cli argument is provided #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,4 +66,10 @@ program
     });
   });
 
+  const optionsLength = process.argv.length;
+  
+  if (optionsLength === 2) {
+    program.help();
+  }
+
 program.parse(process.argv);


### PR DESCRIPTION
### What does this pr do?
This pr fix issue #3 

Previously, when you invoke apl without providing an option, it
brings out a prompt for further input

This PR fixes this error by showing a list of acceptable commands
whenever no option is provided.


